### PR TITLE
Add `cargo_px_env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_px_env"
+version = "0.1.0"
+
+[[package]]
 name = "cfg-expr"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "cargo_px_env"]
+
 [package]
 name = "cargo-px"
 version = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ If there are multiple crates that need to be code-generated, `cargo-px` will inv
 - `CARGO_PX_GENERATED_PKG_MANIFEST_PATH`, the path to the `Cargo.toml` file of the crate that needs to be generated;
 - `CARGO_PX_WORKSPACE_ROOT_DIR`, the path to the `Cargo.toml` file that defines the current workspace (i.e. the one that contains the `[workspace]` section).
 
+You can use the [`cargo_px_env`](https://crates.io/crates/cargo_px_env) crate to retrieve and work with these environment variables.
+
 ## Verify that the generated code is up-to-date
 
 If you are committing the generated code, it might be desirable to verify in CI that it's up-to-date.  

--- a/cargo_px_env/Cargo.toml
+++ b/cargo_px_env/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cargo_px_env"
+version = "0.1.0"
+edition = "2021"
+keywords = ["cargo", "cargo-px", "build", "scripts", "generate"]
+description = "Bindings to retrieve the environment variables set by cargo-px"
+categories = ["development-tools::cargo-plugins"]
+repository = "https://github.com/LukeMathWalker/cargo-px"
+license = "Apache-2.0 OR MIT"

--- a/cargo_px_env/README.md
+++ b/cargo_px_env/README.md
@@ -1,0 +1,8 @@
+# cargo_px_env
+
+Utilities to retrieve the environment variables set by `cargo px`.
+
+When `cargo px` invokes a code generator, it sets various environment variables that 
+can be leveraged by the code generator to retrieve information about the workspace.  
+This crate provides bindings to work with these environment variables instead 
+of hard-coding their names in your code generator.

--- a/cargo_px_env/src/error.rs
+++ b/cargo_px_env/src/error.rs
@@ -1,0 +1,71 @@
+//! Errors that can encountered when loading the environment variables set by `cargo px`.
+
+#[derive(Debug)]
+#[non_exhaustive]
+/// An error that can occur when retrieving the value of an env variable set by `cargo px`.
+pub enum VarError {
+    /// The variable is not set.
+    Missing(MissingVarError),
+    /// The variable contains invalid Unicode data.
+    InvalidUnicode(InvalidUnicodeError),
+}
+
+#[derive(Debug)]
+/// One of the env variables that should be set by `cargo px` is not set.
+pub struct MissingVarError {
+    pub(crate) name: &'static str,
+    pub(crate) source: std::env::VarError,
+}
+
+#[derive(Debug)]
+/// One of the env variables that should be set by `cargo px` contains invalid Unicode data.
+pub struct InvalidUnicodeError {
+    pub(crate) name: &'static str,
+    pub(crate) source: std::env::VarError,
+}
+
+impl std::fmt::Display for VarError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VarError::Missing(e) => std::fmt::Display::fmt(e, f),
+            VarError::InvalidUnicode(e) => std::fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl std::error::Error for VarError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            VarError::Missing(e) => Some(e),
+            VarError::InvalidUnicode(e) => Some(e),
+        }
+    }
+}
+
+impl std::fmt::Display for MissingVarError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The environment variable `{}` is missing. Are you running the command through `cargo px`?", self.name)
+    }
+}
+
+impl std::fmt::Display for InvalidUnicodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "The environment variable `{}` contains invalid Unicode data.",
+            self.name
+        )
+    }
+}
+
+impl std::error::Error for MissingVarError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl std::error::Error for InvalidUnicodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}

--- a/cargo_px_env/src/lib.rs
+++ b/cargo_px_env/src/lib.rs
@@ -1,0 +1,43 @@
+#![doc = include_str!("../README.md")]
+use std::path::PathBuf;
+
+use crate::error::{InvalidUnicodeError, MissingVarError, VarError};
+
+pub mod error;
+
+/// The name of the environment variable that contains the path to the root directory
+/// of the current workspace.
+pub const WORKSPACE_ROOT_DIR_ENV: &str = "CARGO_PX_WORKSPACE_ROOT_DIR";
+/// The name of the environment variable that contains the path to the manifest
+/// of the crate that must be generated.
+pub const GENERATED_PKG_MANIFEST_PATH_ENV: &str = "CARGO_PX_GENERATED_PKG_MANIFEST_PATH";
+
+/// Retrieve the path to the workspace root directory.
+///
+/// It returns an error if the variable is not set or if it contains invalid Unicode data.
+pub fn workspace_root_dir() -> Result<PathBuf, VarError> {
+    px_env_var(WORKSPACE_ROOT_DIR_ENV).map(PathBuf::from)
+}
+
+/// Retrieve the path to the manifest of the crate that must be generated.
+///
+/// It returns an error if the variable is not set or if it contains invalid Unicode data.
+pub fn generated_pkg_manifest_path() -> Result<PathBuf, VarError> {
+    px_env_var(GENERATED_PKG_MANIFEST_PATH_ENV).map(PathBuf::from)
+}
+
+/// Retrieve the value of an env variable set by `cargo px`.
+///
+/// It returns an error if the variable is not set or if it contains invalid Unicode data.
+fn px_env_var(name: &'static str) -> Result<String, VarError> {
+    use std::env::{var, VarError};
+
+    var(name).map_err(|e| match e {
+        VarError::NotPresent => {
+            crate::error::VarError::Missing(MissingVarError { name, source: e })
+        }
+        VarError::NotUnicode(_) => {
+            crate::error::VarError::InvalidUnicode(InvalidUnicodeError { name, source: e })
+        }
+    })
+}


### PR DESCRIPTION
A new library crate to easily access the environment variables set by `cargo_px`.
