### PR TITLE
feat: Pass along the `--quiet` flag to `cargo` invocations if `--quiet` had been specified in `cargo-px`'s invocation

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use cargo_px::Shell;
+use cargo_px::{Shell, Verbosity};
 use std::process::{exit, Command};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 
@@ -46,6 +46,11 @@ fn main() {
     // The first arg is always `cargo` and the second arg is always the name
     // of the sub-command, i.e. `px` in our case.
     let forwarded_args: Vec<_> = std::env::args().skip(2).collect();
+
+    let be_quiet = forwarded_args.iter().any(|arg| arg == "--quiet" || arg == "-q");
+    if be_quiet {
+        shell.set_verbosity(Verbosity::Quiet);
+    }
 
     let mut has_codegened = false;
     if let Some(cargo_command) = forwarded_args.first() {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,7 +47,9 @@ fn main() {
     // of the sub-command, i.e. `px` in our case.
     let forwarded_args: Vec<_> = std::env::args().skip(2).collect();
 
-    let be_quiet = forwarded_args.iter().any(|arg| arg == "--quiet" || arg == "-q");
+    let be_quiet = forwarded_args
+        .iter()
+        .any(|arg| arg == "--quiet" || arg == "-q");
     if be_quiet {
         shell.set_verbosity(Verbosity::Quiet);
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,7 +38,10 @@ fn main() {
         "The `CARGO` environment variable was not set. \
         This is unexpected: it should always be provided by `cargo` when \
         invoking a custom sub-command, allowing `cargo-px` to correctly detect \
-        which toolchain should be used. Please file a bug.",
+        which toolchain should be used. \n\
+        Make sure that you are invoking `cargo-px` as a `cargo` sub-command: `cargo px [...]` rather \
+        than `cargo-px [...]` (notice the missing dash in the first one!). \n
+        If you're invoking it as expected but it's showing this error message, please file a bug.",
     );
     // The first arg is always `cargo` and the second arg is always the name
     // of the sub-command, i.e. `px` in our case.

--- a/src/codegen_unit.rs
+++ b/src/codegen_unit.rs
@@ -84,7 +84,7 @@ impl<'graph> CodegenUnit<'graph> {
 
     /// Build a `std::process::Command` that invokes the code generator for this
     /// codegen unit.
-    pub fn run_command(&self, cargo_path: &str) -> std::process::Command {
+    pub fn run_command(&self, cargo_path: &str, be_quiet: bool) -> std::process::Command {
         let mut cmd = std::process::Command::new(cargo_path);
         cmd.arg("run")
             .arg("--package")
@@ -96,18 +96,24 @@ impl<'graph> CodegenUnit<'graph> {
                 "CARGO_PX_GENERATED_PKG_MANIFEST_PATH",
                 self.package_metadata.manifest_path(),
             );
+        if be_quiet {
+            cmd.arg("--quiet");
+        }
         cmd
     }
 
     /// Build a `std::process::Command` that builds the code generator for this
     /// codegen unit.
-    pub fn build_command(&self, cargo_path: &str) -> std::process::Command {
+    pub fn build_command(&self, cargo_path: &str, be_quiet: bool) -> std::process::Command {
         let mut cmd = std::process::Command::new(cargo_path);
         cmd.arg("build")
             .arg("--package")
             .arg(self.generator_package_metadata.name())
             .arg("--bin")
             .arg(&self.generator_name);
+        if be_quiet {
+            cmd.arg("--quiet");
+        }
         cmd
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod codegen_unit;
 mod config;
 mod shell;
 
-pub use shell::Shell;
+pub use shell::{Shell, Verbosity};
 
 /// Find all codegen units in the current workspace and perform code generation for each of them,
 /// in a order that takes into account their respective dependency relationships.
@@ -40,6 +40,8 @@ fn generate_crate(
     workspace_path: &Path,
     shell: &mut Shell,
 ) -> Result<(), anyhow::Error> {
+    let be_quiet = shell.verbosity() == Verbosity::Quiet;
+
     // Compile generator
     {
         let timer = Instant::now();
@@ -51,7 +53,7 @@ fn generate_crate(
                 unit.package_metadata.name()
             ),
         );
-        let mut cmd = unit.build_command(cargo_path);
+        let mut cmd = unit.build_command(cargo_path, be_quiet);
         cmd.env("CARGO_PX_WORKSPACE_ROOT_DIR", workspace_path)
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());
@@ -83,7 +85,7 @@ fn generate_crate(
     {
         let timer = Instant::now();
         let _ = shell.status("Generating", format!("`{}`", unit.package_metadata.name()));
-        let mut cmd = unit.run_command(cargo_path);
+        let mut cmd = unit.run_command(cargo_path, be_quiet);
         cmd.env("CARGO_PX_WORKSPACE_ROOT_DIR", workspace_path)
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());


### PR DESCRIPTION
When issuing `cargo` commands from inside `cargo-px`, pass along the `--quiet` flag if it was specified by the user.

Generally speaking, we need to do a review of all the flags that should be propagated from the original command to internal `cargo` invocations.